### PR TITLE
Switch from tgmath.h to math.h

### DIFF
--- a/src/3rdparty/CMath/cmath.c
+++ b/src/3rdparty/CMath/cmath.c
@@ -8,7 +8,7 @@
 */
 
 #include "cmath.h"
-#include <tgmath.h>
+#include <math.h>
 
 /*
 * 2d vectors

--- a/src/graphics/font.c
+++ b/src/graphics/font.c
@@ -12,7 +12,6 @@
 
 #define _POSIX_SOURCE
 #include <string.h>
-#include <tgmath.h>
 #include <math.h>
 #include <stdlib.h>
 

--- a/src/graphics/geometry.c
+++ b/src/graphics/geometry.c
@@ -8,7 +8,7 @@
 */
 #include <stdlib.h>
 #include "../math/util.h"
-#include <tgmath.h>
+#include <math.h>
 #include <stdlib.h>
 #include "geometry.h"
 #include "graphics.h"

--- a/src/luaapi/graphics_batch.c
+++ b/src/luaapi/graphics_batch.c
@@ -13,7 +13,6 @@
 #include "graphics_quad.h"
 #include "tools.h"
 
-#include <tgmath.h>
 #include "graphics_batch.h"
 #include "graphics_quad.h"
 #include "graphics_image.h"

--- a/src/math/vector.c
+++ b/src/math/vector.c
@@ -7,6 +7,7 @@
 #   under the terms of the MIT license. See LICENSE.md for details.
 */
 #include "vector.h"
+#include <math.h>
 
 void m4x4_scalexyz(mat4x4 *inout, float x, float y, float z) {
   for(int i = 0; i < 3; ++i) {

--- a/src/math/vector.c
+++ b/src/math/vector.c
@@ -7,7 +7,6 @@
 #   under the terms of the MIT license. See LICENSE.md for details.
 */
 #include "vector.h"
-#include <tgmath.h>
 
 void m4x4_scalexyz(mat4x4 *inout, float x, float y, float z) {
   for(int i = 0; i < 3; ++i) {


### PR DESCRIPTION
While `tgmath.h` includes `math.h`, it may be good to just include `math.h` as it includes just the stuff we need (`sin` and `cos`).

Minimalist dependencies. Also found that it wasn't needed in font, geometry and graphics_batch.